### PR TITLE
Add CFGNOR service.

### DIFF
--- a/tools/template-cia.rsf
+++ b/tools/template-cia.rsf
@@ -175,6 +175,7 @@ AccessControlInfo:
    - cam:u
    - cecd:u
    - cfg:u
+   - cfg:nor
    - dlp:FKCL
    - dlp:SRVR
    - dsp::DSP


### PR DESCRIPTION
This allows 3DS mode apps to write to NVRAM. (ropinstallers)